### PR TITLE
declare utf-8 encoding

### DIFF
--- a/morphic.py
+++ b/morphic.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 #
 #    morphic.py
 #


### PR DESCRIPTION
Explicitly declare the encoding as utf-8 to avoid problems with umlauts and other non ASCII characters.
fixes #1 